### PR TITLE
Move plt import inside functions that use it

### DIFF
--- a/distinctipy/colorblind.py
+++ b/distinctipy/colorblind.py
@@ -1,6 +1,5 @@
 from distinctipy import distinctipy
 
-import matplotlib.pyplot as plt
 import matplotlib.image as mpimg
 
 import numpy as np
@@ -174,6 +173,7 @@ def simulate_image(img_path, colorblind_type):
 
     :return:
     """
+    import matplotlib.pyplot as plt
     filter_function = fBlind[colorblind_type]
 
     img = mpimg.imread(img_path)
@@ -246,6 +246,7 @@ def simulate_colors(colors, colorblind_type='Deuteranomaly', one_row=None):
 
     :return:
     """
+    import matplotlib.pyplot as plt
 
     filtered_colors = [colorblind_filter(color, colorblind_type) for color in colors]
 
@@ -287,6 +288,7 @@ def simulate_clusters(dataset='s2', colorblind_type='Deuteranomaly', colorblind_
 
     :return:
     """
+    import matplotlib.pyplot as plt
 
     if dataset not in ('s1', 's2', 's3', 's4', 'a1','a2', 'a3', 'b1'):
         raise ValueError('dataset must be s1, s2, s3, s4, a1, a2, a3 or b1')

--- a/distinctipy/distinctipy.py
+++ b/distinctipy/distinctipy.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import matplotlib.colors
 import matplotlib.patches as patches
-import matplotlib.pyplot as plt
 
 from . import colorblind
 
@@ -251,6 +250,7 @@ def color_swatch(colors, edgecolors=None, show_text=False, text_threshold=0.6,
 
     :return:
     """
+    import matplotlib.pyplot as plt
     if one_row is None:
         if len(colors) > 8:
             one_row = False

--- a/distinctipy/examples.py
+++ b/distinctipy/examples.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import numpy as np
 
-import matplotlib.pyplot as plt
 import matplotlib.cm
 import matplotlib.colors
 
@@ -27,6 +26,7 @@ def compare_clusters(dataset='a3', compare_with='tab20'):
 
     :return:
     """
+    import matplotlib.pyplot as plt
 
     if dataset not in ('s1', 's2', 's3', 's4', 'a1','a2', 'a3', 'b1'):
         raise ValueError('dataset must be s1, s2, s3, s4, a1, a2, a3 or b1')
@@ -63,6 +63,7 @@ def compare_colors(N=36, compare_with='tab20'):
     :param compare_with: str representing name of a built-in matplotlib colormap
     :return:
     """
+    import matplotlib.pyplot as plt
 
     colors_distinctipy = distinctipy.get_colors(N, exclude_colors=[(1, 1, 1), (0, 0, 0)], return_excluded=False)
 


### PR DESCRIPTION
I'm interested in using this package in a production system.

Overall, it is very well structured and easy to use. There is one tiny issue: `matplotlib.pyplot` has import-time side effects. There is a lot to say here, but the upshot is that you need to ensure you have all matplotlib backend 100% configured before you import `pyplot`, otherwise it can lead to unexpected results.

The `matplotlib` library itself doesn't have this issue, so it's safe to import that at the top-level, but `pyplot` is another story. A reasonable workaround is to simply delay the import of `pyplot` until you actually need it. That gives any external system a change to import all of it's main libraries and then do any user-specific backend customization before any plots are generated.

This is all to say: I moved the `import matplotlib.pyplot as plt` imports into the functions that used them.

Let me know what you think / if there are any issues that you foresee in making this change.