### PR TITLE
Hint for python typing that pastel_factor is a float

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Code quality checks
       run: |
-        isort --check-only .
-        black --check .
+        isort --check-only --diff .
+        black --check --diff .
         flake8
 
   build_and_test:

--- a/distinctipy/__init__.py
+++ b/distinctipy/__init__.py
@@ -12,7 +12,7 @@ Example:
 
 name = "distinctipy"
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"
 
 # Expose these module names and their internals in the top-level API
 __external__ = ["distinctipy"]

--- a/distinctipy/colorblind.py
+++ b/distinctipy/colorblind.py
@@ -24,7 +24,6 @@ def rgb2xyz(rgb):
 
 
 def xyz2rgb(xyz):
-
     x = xyz[0]
     y = xyz[1]
     z = xyz[2]

--- a/distinctipy/distinctipy.py
+++ b/distinctipy/distinctipy.py
@@ -80,7 +80,7 @@ def _ensure_rng(rng):
     return rng
 
 
-def get_random_color(pastel_factor=0., rng=None):
+def get_random_color(pastel_factor=0.0, rng=None):
     """
     Generate a random rgb colour.
 
@@ -126,7 +126,7 @@ def color_distance(c1, c2):
 
 
 def distinct_color(
-    exclude_colors, pastel_factor=0., n_attempts=1000, colorblind_type=None, rng=None
+    exclude_colors, pastel_factor=0.0, n_attempts=1000, colorblind_type=None, rng=None
 ):
     """
     Generate a colour as distinct as possible from the colours defined in exclude_colors
@@ -239,7 +239,7 @@ def get_colors(
     n_colors,
     exclude_colors=None,
     return_excluded=False,
-    pastel_factor=0.,
+    pastel_factor=0.0,
     n_attempts=1000,
     colorblind_type=None,
     rng=None,

--- a/distinctipy/distinctipy.py
+++ b/distinctipy/distinctipy.py
@@ -80,7 +80,7 @@ def _ensure_rng(rng):
     return rng
 
 
-def get_random_color(pastel_factor=0, rng=None):
+def get_random_color(pastel_factor=0., rng=None):
     """
     Generate a random rgb colour.
 
@@ -126,7 +126,7 @@ def color_distance(c1, c2):
 
 
 def distinct_color(
-    exclude_colors, pastel_factor=0, n_attempts=1000, colorblind_type=None, rng=None
+    exclude_colors, pastel_factor=0., n_attempts=1000, colorblind_type=None, rng=None
 ):
     """
     Generate a colour as distinct as possible from the colours defined in exclude_colors
@@ -239,7 +239,7 @@ def get_colors(
     n_colors,
     exclude_colors=None,
     return_excluded=False,
-    pastel_factor=0,
+    pastel_factor=0.,
     n_attempts=1000,
     colorblind_type=None,
     rng=None,


### PR DESCRIPTION
_pastel_factor_ is currently assumed to be an integer by the type checker.
Changing "0" to "0." fixes this.