### PR TITLE
Fix exclude_colors argument name in get_colors() documentation

### DIFF
--- a/distinctipy/distinctipy.py
+++ b/distinctipy/distinctipy.py
@@ -250,8 +250,8 @@ def get_colors(
     :param n_colors: How many colours to generate
 
     :param exclude_colors: A list of (r,g,b) colours that new colours should be distinct
-        from. If exclude_colours=None then exclude_colours will be set to avoid white
-        and black (exclude_colours=[(0,0,0), (1,1,1)]). (r,g,b) values should be floats
+        from. If exclude_colors=None then exclude_colors will be set to avoid white
+        and black (exclude_colors=[(0,0,0), (1,1,1)]). (r,g,b) values should be floats
         between 0 and 1.
 
     :param return_excluded: If return_excluded=True then exclude_colors will be included


### PR DESCRIPTION
In the `get_colors` function's documentation, the argument name `exclude_colours` should be updated to `exclude_colors` to match the actual implementation. Otherwise, copying and pasting the example from the documentation will result in an error.